### PR TITLE
Only display popup when hovering over title of row

### DIFF
--- a/src/documents/index.html.eco
+++ b/src/documents/index.html.eco
@@ -18,8 +18,8 @@ regenerateOnWebhook: true
 	</thead>
 	<tbody>
 		<% for project in @getProjects(): %>
-		<tr class="project title" data-title="<%= project.name %>" data-content="<%= project.description or 'No description' %>">
-			<td><!-- Name -->
+		<tr class="project">
+			<td class="project title" data-title="<%= project.name %>" data-content="<%= project.githubData?.description or 'No description' %>"><!-- Name -->
 				<%= project.name %>
 			</td>
 			<td><!-- Stars -->


### PR DESCRIPTION
Allows popups to be displayed on purpose instead of all the time.  This
prevents a popup from covering a part of the table if it is unwanted.
