### PR TITLE
Github link 404

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -57,7 +57,7 @@ docpadConfig = {
 			# The website's scripts
 			scripts: [
 				'/vendor/semanticui/javascript/semantic.min.js'
-				'//jlukic.github.io/Semantic-UI/javascript/library/tablesort.js'
+				'//cdnjs.cloudflare.com/ajax/libs/tablesort/1.6.1/tablesort.min.js'
 				'/scripts/script.js'
 			].map (url) -> "#{url}?websiteVersion=#{websiteVersion}"
 


### PR DESCRIPTION
Switching to cdnjs, the github link no longer exists.
