### PR TITLE
fix #17 - maybe not the right right way, but better then before

### DIFF
--- a/src/documents/index.html.eco
+++ b/src/documents/index.html.eco
@@ -19,7 +19,7 @@ regenerateOnWebhook: true
 	<tbody>
 		<% for project in @getProjects(): %>
 		<tr class="project">
-			<td class="project title" data-title="<%= project.name %>" data-content="<%= project.githubData?.description or 'No description' %>"><!-- Name -->
+			<td class="project title" data-title="<%= project.name %>" data-content="<%= project.description or 'No description' %>"><!-- Name -->
 				<%= project.name %>
 			</td>
 			<td><!-- Stars -->


### PR DESCRIPTION
I noticed that you have this unused code: `description: project.description or project.githubData?.description or null`

so I set the description to use that value, and now descriptions work. 
